### PR TITLE
sync changes with current ansible version and minor improvements

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-pgbouncer_version: "1.7.2"
+pgbouncer_version: "1.14.0"
 pgbouncer_checksum: "sha256:de36b318fe4a2f20a5f60d1c5ea62c1ca331f6813d2c484866ecb59265a160ba"
 pgbouncer_url: "https://pgbouncer.github.io/downloads/files/{{ pgbouncer_version }}/pgbouncer-{{ pgbouncer_version }}.tar.gz"
 pgbouncer_workspace: "/usr/local/src"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,9 @@
 
 - set_fact:
     pgbouncer_reinstall: yes
-  when: '(pgbouncer_installed_version|success and (pgbouncer_installed_version.stdout | regex_replace("^.*?([0-9\.]+)$", "\\1") | version_compare(pgbouncer_version, operator="!=")))'
+  when:
+    - pgbouncer_installed_version.failed | bool
+    - '(pgbouncer_installed_version.msg | regex_replace("^.*?([0-9\.]+)$", "\\1")) is version(pgbouncer_version, operator="!=")'
   tags: pgbouncer
 
 - block:
@@ -73,8 +75,14 @@
         creates: "{{ pgbouncer_workspace }}/pgbouncer-{{ pgbouncer_version }}/README.rst"
         copy: no
 
+    - name: Pgbouncer | autogen
+      command: ./autogen.sh
+      args:
+        chdir: "{{ pgbouncer_workspace }}/pgbouncer-{{ pgbouncer_version }}"
+        creates: "{{ pgbouncer_workspace }}/pgbouncer-{{ pgbouncer_version }}/autogen"
+
     - name: Pgbouncer | Configure install
-      command: ./configure --prefix={{ pgbouncer_install_path }} {{ pgbouncer_libevent_path|ternary('--with-libevent='~pgbouncer_libevent_path,'') }}
+      command: ./configure --with-systemd --prefix={{ pgbouncer_install_path }}
       args:
         chdir: "{{ pgbouncer_workspace }}/pgbouncer-{{ pgbouncer_version }}"
         creates: "{{ pgbouncer_workspace }}/pgbouncer-{{ pgbouncer_version }}/config.log"
@@ -90,7 +98,7 @@
       args:
         chdir: "{{ pgbouncer_workspace }}/pgbouncer-{{ pgbouncer_version }}"
 
-  when: pgbouncer_installed_version|failed or pgbouncer_reinstall        
+  when: pgbouncer_installed_version.failed|bool or pgbouncer_reinstall
   tags: pgbouncer
 
 - name: Pgbouncer | Write configuration file
@@ -111,6 +119,9 @@
     group: "{{ pgbouncer_run_as_group }}"
     mode: 0640
   register: pgbouncer_auth
+  when:
+    - pgbouncer_auth_user is defined
+    - pgbouncer_auth_password is defined
   tags: pgbouncer
 
 - name: Pgbouncer | Write service file
@@ -135,7 +146,7 @@
     name: pgbouncer.service
     state: reloaded
     daemon_reload: yes
-  when: (not pgbouncer_service|changed) and (pgbouncer_conf|changed or pgbouncer_auth|changed)
+  when: (not pgbouncer_service.changed) and (pgbouncer_conf.changed or pgbouncer_auth.changed)
   tags: pgbouncer
 
 - name: Pgbouncer | Restart
@@ -143,5 +154,5 @@
     name: pgbouncer.service
     state: restarted
     daemon_reload: yes
-  when: pgbouncer_service|changed
+  when: pgbouncer_service.changed
   tags: pgbouncer

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,14 @@
   file: path={{ pgbouncer_socket_path }} state=directory mode=2750 owner={{ pgbouncer_run_as_user }} group={{ pgbouncer_run_as_group }}
   tags: pgbouncer
 
+- name: Pgbouncer | Ensure log dir exists
+  file: path={{ pgbouncer_log_file|dirname }} state=directory mode=2750 owner={{ pgbouncer_run_as_user }} group={{ pgbouncer_run_as_group }}
+  tags: pgbouncer
+
+- name: Pgbouncer | Ensure log file exists
+  file: path={{ pgbouncer_log_file }} state=touch mode=0755 owner={{ pgbouncer_run_as_user }} group={{ pgbouncer_run_as_group }}
+  tags: pgbouncer
+
 - name: Pgbouncer | Get installed version
   command: pgbouncer -V
   ignore_errors: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,22 +4,22 @@
   with_first_found:
     - "{{ ansible_os_family }}.yml"
     - "empty.yml"
-  tags: pgbouncer
+  tags: pgbouncer-dependencies
 
 - name: Pgbouncer | Set dependencies
   set_fact:
     pgbouncer_dependencies: "{{ __pgbouncer_dependencies }}"
   when: pgbouncer_dependencies is not defined
-  tags: pgbouncer
+  tags: pgbouncer-dependencies
 
 - name: Pgbouncer | Ensure dependencies are installed
   package: "name={{ item }} state=latest"
   with_items: "{{ pgbouncer_dependencies }}"
-  tags: pgbouncer
+  tags: pgbouncer-dependencies
 
 - name: Pgbouncer | Ensure pgbouncer group exists
   group: name={{ pgbouncer_run_as_group }} state=present
-  tags: pgbouncer
+  tags: pgbouncer-dependencies
 
 - name: Pgbouncer | Ensure pgbouncer user exists
   user:
@@ -29,37 +29,37 @@
     home: "{{ pgbouncer_conf_file|dirname }}"
     createhome: no
     state: present
-  tags: pgbouncer
+  tags: pgbouncer-dependencies
 
 - name: Pgbouncer | Ensure conf dir exists
   file: path={{ pgbouncer_conf_file|dirname }} state=directory mode=0755 owner={{ pgbouncer_run_as_user }} group={{ pgbouncer_run_as_group }}
-  tags: pgbouncer
+  tags: pgbouncer-dependencies
 
 - name: Pgbouncer | Ensure socket path exists
   file: path={{ pgbouncer_socket_path }} state=directory mode=2750 owner={{ pgbouncer_run_as_user }} group={{ pgbouncer_run_as_group }}
-  tags: pgbouncer
+  tags: pgbouncer-dependencies
 
 - name: Pgbouncer | Ensure log dir exists
   file: path={{ pgbouncer_log_file|dirname }} state=directory mode=2750 owner={{ pgbouncer_run_as_user }} group={{ pgbouncer_run_as_group }}
-  tags: pgbouncer
+  tags: pgbouncer-dependencies
 
 - name: Pgbouncer | Ensure log file exists
   file: path={{ pgbouncer_log_file }} state=touch mode=0755 owner={{ pgbouncer_run_as_user }} group={{ pgbouncer_run_as_group }}
-  tags: pgbouncer
+  tags: pgbouncer-dependencies
 
 - name: Pgbouncer | Get installed version
   command: pgbouncer -V
   ignore_errors: yes
   changed_when: no
   register: pgbouncer_installed_version
-  tags: pgbouncer
+  tags: pgbouncer-install
 
 - set_fact:
     pgbouncer_reinstall: yes
   when:
     - pgbouncer_installed_version.failed | bool
     - '(pgbouncer_installed_version.msg | regex_replace("^.*?([0-9\.]+)$", "\\1")) is version(pgbouncer_version, operator="!=")'
-  tags: pgbouncer
+  tags: pgbouncer-install
 
 - block:
     - name: Pgbouncer | Download tarball
@@ -99,7 +99,7 @@
         chdir: "{{ pgbouncer_workspace }}/pgbouncer-{{ pgbouncer_version }}"
 
   when: pgbouncer_installed_version.failed|bool or pgbouncer_reinstall
-  tags: pgbouncer
+  tags: pgbouncer-install
 
 - name: Pgbouncer | Write configuration file
   template:
@@ -109,7 +109,9 @@
     group: root
     mode: 0644
   register: pgbouncer_conf
-  tags: pgbouncer
+  tags:
+    - pgbouncer-install
+    - pgbouncer-config
 
 - name: Pgbouncer | Write auth file
   template:
@@ -122,7 +124,9 @@
   when:
     - pgbouncer_auth_user is defined
     - pgbouncer_auth_password is defined
-  tags: pgbouncer
+  tags:
+    - pgbouncer-install
+    - pgbouncer-config
 
 - name: Pgbouncer | Write service file
   template:
@@ -132,14 +136,20 @@
     group: root
     mode: 0644
   register: pgbouncer_service
-  tags: pgbouncer
+  tags:
+    - pgbouncer-install
+    - pgbouncer-config
+    - pgbouncer-systemd
 
 - name: Pgbouncer | Enable and start service
   systemd:
     name: pgbouncer.service
     state: started
     enabled: yes
-  tags: pgbouncer
+  tags:
+    - pgbouncer-install
+    - pgbouncer-config
+    - pgbouncer-systemd
 
 - name: Pgbouncer | Reload
   systemd:
@@ -147,7 +157,10 @@
     state: reloaded
     daemon_reload: yes
   when: (not pgbouncer_service.changed) and (pgbouncer_conf.changed or pgbouncer_auth.changed)
-  tags: pgbouncer
+  tags:
+    - pgbouncer-install
+    - pgbouncer-config
+    - pgbouncer-systemd
 
 - name: Pgbouncer | Restart
   systemd:
@@ -155,4 +168,7 @@
     state: restarted
     daemon_reload: yes
   when: pgbouncer_service.changed
-  tags: pgbouncer
+  tags:
+    - pgbouncer-install
+    - pgbouncer-config
+    - pgbouncer-systemd

--- a/templates/pgbouncer.ini.j2
+++ b/templates/pgbouncer.ini.j2
@@ -1,3 +1,5 @@
+#jinja2: trim_blocks: True
+
 [pgbouncer]
 logfile = {{ pgbouncer_log_file }}
 pidfile = {{ pgbouncer_pid_file }}
@@ -30,5 +32,6 @@ stats_users = {{ pgbouncer_stats_users|join(",") }}
 {% if database.comment is defined %}
 # {{ database.comment }}
 {% endif %}
-{{ database.name }} = host={{ database.host }} dbname={{ database.dbname }} client_encoding={{ database.encoding }} auth_user={{ database.auth_user }}
+{{ database.name }} = host={{ database.host }} {%- if database.dbname is defined %} dbname={{ database.dbname }} {%- endif %} {%- if database.client_encoding is defined %} client_encoding={{ database.client_encoding }} {%- endif %} {%- if database.auth_user is defined %} auth_user={{ database.auth_user }} {%- endif %}
+
 {% endfor %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,4 +3,10 @@ __pgbouncer_dependencies:
   - build-essential
   - libssl-dev
   - libevent-dev
-
+  - libtool
+  - make
+  - automake
+  - gcc
+  - pkg-config
+  - m4
+  - libsystemd-dev

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,5 +8,4 @@ __pgbouncer_dependencies:
   - automake
   - gcc
   - pkg-config
-  - m4
   - libsystemd-dev


### PR DESCRIPTION
PR was opened as follow: https://github.com/corford/ansible-role-pgbouncer/pull/3

* update pgbouncer latest version to 1.14.0
* split tags between task groups
* update dependencies as follows https://github.com/pgbouncer/pgbouncer#building
* fix some conditions: failed filter doesn't exists
* pgbouncer.ini j2 template improvements